### PR TITLE
Add random movement if nothing is happening, for hiker/hiking pole

### DIFF
--- a/mods-unpacked/Pasha-AutoBattler/extensions/entities/units/movement_behaviors/player_movement_behavior.gd
+++ b/mods-unpacked/Pasha-AutoBattler/extensions/entities/units/movement_behaviors/player_movement_behavior.gd
@@ -245,5 +245,8 @@ func get_movement()->Vector2:
 		
 	if (shooting_anyone and not must_run_away) and is_soldier:
 		return Vector2.ZERO
+
+        if (move_vector == Vector2.ZERO):
+                move_vector = Vector2(rand_range(-1, 1), rand_range(-1, 1))
 		
 	return move_vector.normalized()


### PR DESCRIPTION
Something you may be interested in implementing.
Random movement during the first few seconds of the round before any enemies spawn.

Perhaps can only enable this if the character is hiker or have the hiking pole?